### PR TITLE
Omitting Stale Measurements

### DIFF
--- a/OpenCTD_master
+++ b/OpenCTD_master
@@ -20,7 +20,7 @@ char *SAL_str;     // Used for serial monitor because I think in SAL, but data s
 char *GRAV_str;    // TODO: Parsed but not logged.
 
 byte chars_received = 0;        // How many characters have been received, reading into EC_data.
-byte string_received = 0;       // Whether it received a string from the EC circuit. TODO: Boolean (1/0)? Remove?
+byte EC_data_valid = 0;         // Flag to track whether EC_data has been recently parsed into useful values.
 
 #define rx 2  // Set rx to pin 2 for conductivity.
 #define tx 3  // Set tx to pin 3 for conductivity.
@@ -59,19 +59,24 @@ void setup(void) {
 
 void loop(void) {
 
+  EC_data_valid = 0;  // Reset the data freshness flag.
+
   // Read any pending data from the EC circuit.
   if (ecSerial.available() > 0) {
     chars_received = ecSerial.readBytesUntil(13, EC_data, 48);
 
     // Null terminate the data by setting the value after the final character to 0.
     EC_data[chars_received] = 0;
-  }
 
-  // TODO: Add a comment here depicting an example string from the EC circuit.
+    // TODO: Add a comment here depicting an example string from the EC circuit.
 
-  // Parse data, if EC_data begins with a digit, not a letter (testing ASCII values).
-  if ((EC_data[0] >= 48) && (EC_data[0] <=57)) {
-    parse_data();
+    // Parse data, if EC_data begins with a digit, not a letter (testing ASCII values).
+    if ((EC_data[0] >= 48) && (EC_data[0] <=57)) {
+      parse_data();
+
+      EC_data_valid = 1;  // The latest measurements have been successfully parsed.
+    }
+
   }
 
   delay(10);  // Wait 10 milliseconds.
@@ -106,7 +111,7 @@ void loop(void) {
     dataFile.print("  ");
     dataFile.print(PS_float);
     dataFile.print("  ");      
-    dataFile.print(EC_str);
+    dataFile.print(EC_data_valid != 1 ? "---" : EC_str);
     dataFile.println("");
     dataFile.close();
   }
@@ -123,9 +128,9 @@ void loop(void) {
   monitorSerial.print("  ");
   monitorSerial.print(PS_float);
   monitorSerial.print("  ");
-  monitorSerial.print(SAL_str); 
+  monitorSerial.print(EC_data_valid != 1 ? "---" : SAL_str); 
   monitorSerial.print("  ");
-  monitorSerial.print(EC_str);
+  monitorSerial.print(EC_data_valid != 1 ? "---" : EC_str);
   monitorSerial.println("");
 
   delay(50);  // Wait 50 milliseconds.
@@ -135,9 +140,9 @@ void loop(void) {
 
 void parse_data() {
 
-  EC_str = strtok(EC_data, ",");               
-  TDS_str = strtok(NULL, ",");                
-  SAL_str = strtok(NULL, ",");                
-  GRAV_str = strtok(NULL, ",");                
+  EC_str = strtok(EC_data, ",");
+  TDS_str = strtok(NULL, ",");
+  SAL_str = strtok(NULL, ",");
+  GRAV_str = strtok(NULL, ",");
 
 }


### PR DESCRIPTION
Extrapolating possible intent from that "string_received" global before, this patch only prints EC_data values if they were obtained during the current loop() iteration. Otherwise, "---" is logged instead, via ternary operator magic.
.
.
Sidenote: ecSerial.readBytesUntil(13, ...) seems fairly safe. It only threatens incomplete reads if you underestimate the max chars per line - or if the device becomes unresponsive until the serial's adjustable timeout is reached (default: 1 second).
.
.
- If the device is wants to send a huge line or is laggy beyond a reasonable timeout, the parser will get very confused.
  - (The vulnerability exists already and would be unaffected by this patch.)
- If the device is unavailable or sent an uninteresting line of text, nothing will be printed during that loop().
  - (This patch happens to fix an edge case where that could happen on the first loop() and leave the values undefined.)
- The rest of the time, I expect EC_data should be valid.
